### PR TITLE
Feat/flatten objects

### DIFF
--- a/example.config.json
+++ b/example.config.json
@@ -27,7 +27,8 @@
 		"category.title",
 		"description",
 		"tags.tags_id.tag"
-	  ]
+	  ],
+	  "flatten": true
 	}
   }
 }

--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-module.exports = function registerHook({ services, env, database }) {
-	const { schemaInspector } = require(env.DIRECTUS_DEV
-		? require.main.path + "/../dist/database"
-		: "directus/dist/database");
-
+module.exports = function registerHook({ services, env, database, getSchema }) {
 	const extensionConfig = require(env.EXTENSION_SEARCHSYNC_CONFIG ||
 		"./config.json");
 
@@ -54,9 +50,9 @@ module.exports = function registerHook({ services, env, database }) {
 	}
 
 	async function reindexCollection(collection) {
-		const schema = await schemaInspector.overview();
+		const schema = await getSchema();
 		const query = new services.ItemsService(collection, { database, schema });
-		const pk = schema[collection].primary;
+		const pk = schema['tables'][collection].primary;
 		const items = await query.readByQuery({
 			fields: [pk],
 			filter: extensionConfig.collections[collection].filter || [],
@@ -78,7 +74,7 @@ module.exports = function registerHook({ services, env, database }) {
 		const body = await getItemObject(collection, id, schema);
 		try {
 			if (body) {
-				indexer.updateItem(collection, id, body, schema[collection].primary);
+				indexer.updateItem(collection, id, body, schema['tables'][collection].primary);
 			} else {
 				indexer.deleteItem(collection, id);
 			}

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+const flattenObject = require('./utils');
+
 module.exports = function registerHook({ services, env, database, getSchema }) {
 	const extensionConfig = require(env.EXTENSION_SEARCHSYNC_CONFIG ||
 		"./config.json");
@@ -88,10 +90,15 @@ module.exports = function registerHook({ services, env, database, getSchema }) {
 			knex: database,
 			schema: schema,
 		});
-		return await query.readByKey(id, {
+		const data = await query.readByKey(id, {
 			fields: extensionConfig.collections[collection].fields,
 			filter: extensionConfig.collections[collection].filter || [],
 		});
+		if (extensionConfig.collections[collection].flatten) {
+			return flattenObject(data);
+		} else {
+			return data;
+		}
 	}
 
 	function hookEventHandler(callback, input) {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,19 @@
+module.exports = function flattenObject(ob) {
+	var toReturn = {};
+
+	for (var i in ob) {
+		if (!ob.hasOwnProperty(i)) continue;
+
+		if (typeof ob[i] == 'object' && ob[i] !== null) {
+			var flatObject = flattenObject(ob[i]);
+			for (var x in flatObject) {
+				if (!flatObject.hasOwnProperty(x)) continue;
+
+				toReturn[i + '.' + x] = flatObject[x];
+			}
+		} else {
+			toReturn[i] = ob[i];
+		}
+	}
+	return toReturn;
+}


### PR DESCRIPTION
Adds a new option to flatten data before indexing, for easier handling of nested objects, for example translated data.

Flattens the Directus data keys to dot notation, for example:

```js
{
  name: 'helga',
  profession: {
    id: 1,
    title: 'driver'
  },
  translations: [
    {
      lang: 'en',
      title: 'driver'
    },
    {
      lang: 'fr',
      title: 'chauffeur'
    }
  ],
}
```

Transforms into

```js
{
  name: 'helga',
  profession.id: 1,
  profession.title: 'driver',
  translations.0.lang: 'en',
  translations.0.title: 'driver',
  translations.1.lang: 'fr',
  translations.1.title: 'chauffeur',
}
```

It's a bit awkward for arrays but it works and it's reasonably painless to parse the search results back into a similar object that was in Directus

This branch is based on the RC update branch (https://github.com/dimitrov-adrian/directus-extension-searchsync/pull/1), so there's an extra commit before the main contents of this pr :)