### PR TITLE
Make drop index in algolia.js less destructive

### DIFF
--- a/indexers/algolia.js
+++ b/indexers/algolia.js
@@ -33,7 +33,7 @@ module.exports = function algolia(config) {
 
 	async function dropIndex(collection) {
 		try {
-			return await axios.delete(`${endpoint}/${collection}`, axiosConfig);
+			return await axios.post(`${endpoint}/${collection}/clear`, null, axiosConfig);
 		} catch (error) {
 			if (error.response && error.response.status === 404) {
 				return;


### PR DESCRIPTION
When testing out the algolia.js integration, I was suprised that when `reindexOnStart` is enabled, that the entire index including all settings, facets, rankings etc. gets wiped.

That seems too destructive so this pull request aims at softening this to just delete the objects in the index, retaining all settings as they are.