### PR TITLE
Support new Meilisearch authorization headers

### DIFF
--- a/lib/indexers/meilisearch.js
+++ b/lib/indexers/meilisearch.js
@@ -14,6 +14,13 @@ module.exports = function meilisearch(config) {
 	};
 
 	if (config.key) {
+		// Meilisearch changed their authorization in 0.25 from the
+		// 'X-Meili-API-Key' header to Authorization bearer.
+
+		// Include old headers for compatibility with pre-0.25 versions of Meilisearch
+		axiosConfig.headers['X-Meili-API-Key'] = config.key;
+
+		// New auth headers for 0.25+
 		axiosConfig.headers['Authorization'] = `Bearer ${config.key}`;
 	}
 

--- a/lib/indexers/meilisearch.js
+++ b/lib/indexers/meilisearch.js
@@ -14,7 +14,7 @@ module.exports = function meilisearch(config) {
 	};
 
 	if (config.key) {
-		axiosConfig.headers['X-Meili-API-Key'] = config.key;
+		axiosConfig.headers['Authorization'] = `Bearer ${config.key}`;
 	}
 
 	if (!config.host) {


### PR DESCRIPTION
The latest version of Meilisearch includes a breaking change to the request authorization headers: https://github.com/meilisearch/MeiliSearch/releases/tag/v0.25.0

In this PR I added the new headers alongside the old X-MEILI-API-KEY (so this extension can still support pre-0.25 versions of Meilisearch).