### PR TITLE
Allow collections missing in config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,14 +35,17 @@ function registerHook({ action, init }, { services, env, database, logger, getSc
 	});
 
 	action('items.create', ({ collection, key }) => {
+		if (!(extensionConfig.collections.hasOwnProperty(collection))) return;
 		indexer.updateItemIndex(collection, [key]);
 	});
 
 	action('items.update', ({ collection, keys }) => {
+		if (!(extensionConfig.collections.hasOwnProperty(collection))) return;
 		indexer.updateItemIndex(collection, keys);
 	});
 
 	action('items.delete', ({ collection, payload }) => {
+		if (!(extensionConfig.collections.hasOwnProperty(collection))) return;
 		indexer.deleteItemIndex(collection, payload);
 	});
 


### PR DESCRIPTION
When not all directus collections are present in the config, the getCollectionIndexName function inside create-indexer.js throws an error when adding or updating items in these collections. In this pull request, I added checks to the action hooks that skip the handling of items, if the collection is missing in the config.