### PR TITLE
fixes relational fields not being written into the index

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,27 @@ New typeless behaviour, use collection names as index name.
 }
 ```
 
+Use Authentification.
+
+```json
+{
+	"type": "elasticsearch",
+	"host": "http://search:9200/",
+	"username": "elastic",
+	"password": "somepassword"
+}
+```
+
+Ignore ssl-certificate-error.
+
+```json
+{
+	"type": "elasticsearch",
+	"host": "http://search:9200/",
+	"ignore_cert": true,
+}
+```
+
 ##### ElasticSearch for 5.x and 6.x
 
 Old type behaviour, use collection names as types.

--- a/lib/create-indexer.js
+++ b/lib/create-indexer.js
@@ -182,7 +182,7 @@ function createIndexer(config, { logger, database, services, getSchema }) {
 			};
 		} else if (config.collections[collection].fields) {
 			return {
-				...filteredObject(body, config.collections[collection].fields),
+				...flattenObject(body),
 				...meta,
 			};
 		}

--- a/lib/create-indexer.js
+++ b/lib/create-indexer.js
@@ -182,7 +182,7 @@ function createIndexer(config, { logger, database, services, getSchema }) {
 			};
 		} else if (config.collections[collection].fields) {
 			return {
-				...flattenObject(body),
+				...filteredObject(flattenObject(body), config.collections[collection].fields),
 				...meta,
 			};
 		}

--- a/lib/indexers/elasticsearch.js
+++ b/lib/indexers/elasticsearch.js
@@ -1,4 +1,5 @@
 const { URL } = require('url');
+const https = require('https');
 
 /**
  * @type {import("axios").AxiosInstance}
@@ -9,12 +10,28 @@ const axios = require('axios');
  * @type {import("../../types.js").IndexerInterface}
  */
 module.exports = function elasticsearch(config) {
+
 	const axiosConfig = {
 		headers: {
 			'Content-Type': 'application/json',
 			...(config.headers || {}),
-		},
+		}
 	};
+
+	if(config.username && config.password) {
+		axiosConfig.auth = {
+			username: config.username,
+			password: config.password
+		}
+	}
+
+	if(config.ignore_cert) {
+		const agent = new https.Agent({  
+			rejectUnauthorized: false
+		});
+	
+		axiosConfig.httpsAgent = agent;
+	}
 
 	if (!config.host) {
 		throw Error('No HOST set. The server.host is mandatory.');


### PR DESCRIPTION
- filtering removes relational fields from items, so instead of filtering the item the items get just flattened
- adds authentification to elasticsearch and an option to ignore certificate errors