### PR TITLE
Feature: Support directus `deep` query parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@ So, configuration should comes from one of next files:
 - `reindexOnStart: boolean` Performs full reindex of all documents upon Directus starts
 - `collections: object` Indexing data definition
 - `collections.<collection>.filter: object` The filter query in format like Directus on which item must match to be
-  indexed (check [Filter Rules ](https://docs.directus.io/reference/filter-rules/#filter-rules))
+  indexed (check [Filter Rules](https://docs.directus.io/reference/filter-rules/#filter-rules))
+- `collections.<collection>.deep: object` The deep query in format like Directus on which item must match to be
+  indexed (check [Deep Parameter](https://docs.directus.io/reference/query.html#deep))
 - `collections.<collection>.fields: array<string>` Fields that will be indexed in Directus format
 - `collections.<collection>.transform: function` (Could be defined only if config file is .js) A callback to return
   transformed/formatted data for indexing.

--- a/lib/create-indexer.js
+++ b/lib/create-indexer.js
@@ -73,6 +73,7 @@ function createIndexer(config, { logger, database, services, getSchema }) {
 			const items = await query.readByQuery({
 				fields: [pk],
 				filter: config.collections[collection].filter || [],
+				deep: config.collections[collection].deep || {},
 				limit,
 				offset,
 			});
@@ -121,6 +122,7 @@ function createIndexer(config, { logger, database, services, getSchema }) {
 		const items = await query.readMany(ids, {
 			fields: config.collections[collection].fields ? [pk, ...config.collections[collection].fields] : ['*'],
 			filter: config.collections[collection].filter || [],
+			deep: config.collections[collection].deep || {},
 		});
 
 		/**


### PR DESCRIPTION
By adding the `deep` parameter to the configuration for a collection being indexed, we could apply any of directus query parameters to nested fields withing the collection, which the `filter` parameter does not allow. 

The reference would be as follows:

`collections.<collection>.deep: object` The deep query in format like Directus on which item must match to be indexed (check [Deep Parameter](https://docs.directus.io/reference/query.html#deep))

Closes #22 